### PR TITLE
Add registry option

### DIFF
--- a/options.go
+++ b/options.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"golang.org/x/net/context"
+
+	"github.com/micro/go-micro/registry"
 )
 
 type Options struct {
@@ -17,6 +19,7 @@ type Options struct {
 
 	RegisterTTL      time.Duration
 	RegisterInterval time.Duration
+	Registry         registry.Registry
 
 	Handler http.Handler
 
@@ -32,6 +35,7 @@ func newOptions(opts ...Option) Options {
 		Address:          DefaultAddress,
 		RegisterTTL:      DefaultRegisterTTL,
 		RegisterInterval: DefaultRegisterInterval,
+		Registry:         registry.DefaultRegistry,
 	}
 
 	for _, o := range opts {
@@ -98,5 +102,12 @@ func RegisterInterval(t time.Duration) Option {
 func Handler(h http.Handler) Option {
 	return func(o *Options) {
 		o.Handler = h
+	}
+}
+
+// Set registry to be used by the service
+func Registry(r registry.Registry) Option {
+	return func(o *Options) {
+		o.Registry = r
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,23 @@
+package web
+
+import (
+	"testing"
+
+	"github.com/micro/go-micro/registry"
+	"github.com/micro/go-micro/registry/mock"
+)
+
+func TestDefaultRegistry(t *testing.T) {
+	opts := newOptions()
+	if want, have := registry.DefaultRegistry, opts.Registry; want != have {
+		t.Errorf("unexpected registry: want %v, have %v", want, have)
+	}
+}
+
+func TestRegistryOption(t *testing.T) {
+	registry := mock.NewRegistry()
+	opts := newOptions(Registry(registry))
+	if want, have := registry, opts.Registry; want != have {
+		t.Errorf("unexpected registry: want %v, have %v", want, have)
+	}
+}

--- a/service.go
+++ b/service.go
@@ -99,7 +99,7 @@ func (s *service) register() error {
 	if s.srv == nil {
 		return nil
 	}
-	return registry.Register(s.srv, registry.RegisterTTL(s.opts.RegisterTTL))
+	return s.opts.Registry.Register(s.srv, registry.RegisterTTL(s.opts.RegisterTTL))
 }
 
 func (s *service) deregister() error {

--- a/service_test.go
+++ b/service_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/micro/go-micro/registry"
 	"github.com/micro/go-micro/registry/mock"
 )
 
@@ -18,11 +17,11 @@ func TestService(t *testing.T) {
 		fmt.Fprint(w, str)
 	}
 
-	// ugly hack
-	registry.DefaultRegistry = registry.Registry(mock.NewRegistry())
+	registry := mock.NewRegistry()
 
 	service := NewService(
 		Name("go.micro.web.test"),
+		Registry(registry),
 	)
 
 	service.HandleFunc("/", fn)


### PR DESCRIPTION
I would like to switch the registry used by the service without having to change `registry.DefaultRegistry`.