### PR TITLE
Add cmd options and before/after server run callbacks

### DIFF
--- a/options.go
+++ b/options.go
@@ -6,6 +6,8 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/micro/cli"
+	"github.com/micro/go-micro/cmd"
 	"github.com/micro/go-micro/registry"
 )
 
@@ -24,6 +26,12 @@ type Options struct {
 
 	// Alternative Options
 	Context context.Context
+
+	Cmd         cmd.Cmd
+	BeforeStart []func() error
+	BeforeStop  []func() error
+	AfterStart  []func() error
+	AfterStop   []func() error
 }
 
 func newOptions(opts ...Option) Options {
@@ -34,6 +42,7 @@ func newOptions(opts ...Option) Options {
 		Address:          DefaultAddress,
 		RegisterTTL:      DefaultRegisterTTL,
 		RegisterInterval: DefaultRegisterInterval,
+		Cmd:              cmd.DefaultCmd,
 	}
 
 	for _, o := range opts {
@@ -107,5 +116,54 @@ func Handler(h http.Handler) Option {
 func Registry(r registry.Registry) Option {
 	return func(o *Options) {
 		registry.DefaultRegistry = r
+	}
+}
+
+// Cmd sets the command instance.
+func Cmd(c cmd.Cmd) Option {
+	return func(o *Options) {
+		o.Cmd = c
+	}
+}
+
+// Flags sets the command flags.
+func Flags(flags ...cli.Flag) Option {
+	return func(o *Options) {
+		o.Cmd.App().Flags = append(o.Cmd.App().Flags, flags...)
+	}
+}
+
+// Action sets the command action.
+func Action(a func(*cli.Context)) Option {
+	return func(o *Options) {
+		o.Cmd.App().Action = a
+	}
+}
+
+// BeforeStart is executed before the server starts.
+func BeforeStart(fn func() error) Option {
+	return func(o *Options) {
+		o.BeforeStart = append(o.BeforeStart, fn)
+	}
+}
+
+// BeforeStop is executed before the server stops.
+func BeforeStop(fn func() error) Option {
+	return func(o *Options) {
+		o.BeforeStop = append(o.BeforeStop, fn)
+	}
+}
+
+// AfterStart is executed after server start.
+func AfterStart(fn func() error) Option {
+	return func(o *Options) {
+		o.AfterStart = append(o.AfterStart, fn)
+	}
+}
+
+// AfterStop is executed after server stop.
+func AfterStop(fn func() error) Option {
+	return func(o *Options) {
+		o.AfterStop = append(o.AfterStop, fn)
 	}
 }


### PR DESCRIPTION
This PR adds new options to let us interoperate with command instance and execute code before/after server run.

The new options are:

* `Cmd`
* `Action`
* `Flags`
* `BeforeStart` 
* `AfterStart` 
* `BeforeStop` 
* `AfterStop`

Similar to `go-micro` ones.

(Thanks @asim for this awesome project).