### PR TITLE
Advertise the listening port if no-port provided

### DIFF
--- a/service.go
+++ b/service.go
@@ -127,6 +127,13 @@ func (s *service) start() error {
 	srv.Endpoints = s.srv.Endpoints
 	s.srv = srv
 
+	// Update the advertisment address if it's port is set to 0 with
+	// that chosen by the listener.
+	_, port, _ := net.SplitHostPort(s.opts.Address)
+	if port != "" && s.srv.Nodes[0].Port == 0 {
+		s.srv.Nodes[0].Port, _ = strconv.Atoi(port)
+	}
+
 	var h http.Handler
 
 	if s.opts.Handler != nil {


### PR DESCRIPTION
Port 0 is marked "reserved" by IANA. On most (all?) operating systems, trying to bind to port 0 will actually bind to a random ephemeral port. Port 0 should not be seen in normal traffic.

RFC 6056 basically covers this behaviour.

This makes deploying services easier because we don't have to know what port things are running on to deploy several of them, they just advertise whatever port they get.
